### PR TITLE
Not much can be done

### DIFF
--- a/source/types.ts
+++ b/source/types.ts
@@ -1,6 +1,6 @@
 export type Bit = 0 | 1
-export type Bits = Array<Bit>
-export type BooleanBits = Array<boolean>
+export type Bits = Bit[]
+export type BooleanBits = boolean[]
 export type Byte = [Bit, Bit, Bit, Bit, Bit, Bit, Bit, Bit]
 export type Nibble = [Bit, Bit, Bit, Bit]
 


### PR DESCRIPTION
So generally speaking other than using the slightly shorter array on the Bits and BinaryBits types

Not much can be done regarding the unsigned int types.
Your salvation may come with this proposal should the day come https://github.com/Microsoft/TypeScript/issues/15480

But Typescript will probably not support base uint[n] types as this discussion ended 
https://github.com/Microsoft/TypeScript/issues/4639
essentially JS is expecting BigInt and other types may be added someday and so no extra primitives will be added until T39 adds them

on a side note this regex proposal should it get implemented would be interesting 
https://github.com/Microsoft/TypeScript/issues/6579

Feel free to obviously reject this change since the request is a stylistic one